### PR TITLE
Update recipe for building sheetjs webjar 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Webjar for SheetJS
 
 More info: http://webjars.org
 
-Upstream: https://github.com/sheetjs/sheetjs
+Upstream: https://git.sheetjs.com/sheetjs/sheetjs

--- a/pom.xml
+++ b/pom.xml
@@ -11,14 +11,14 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>sheetjs</artifactId>
-    <version>0.12.5-SNAPSHOT</version>
+    <version>0.18.7</version>
     <name>sheetjs</name>
     <description>WebJar for sheetjs</description>
     <url>http://webjars.org</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>0.12.4</upstream.version>
+        <upstream.version>0.18.7</upstream.version>
         <upstream.url>https://git.sheetjs.com/sheetjs/sheetjs.git/archive/v${upstream.version}.zip</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
         <requirejs>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <upstream.version>0.12.4</upstream.version>
-        <upstream.url>https://github.com/SheetJS/sheetjs/archive/refs/tags/v${upstream.version}.zip</upstream.url>
+        <upstream.url>https://git.sheetjs.com/sheetjs/sheetjs.git/archive/v${upstream.version}.zip</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
         <requirejs>
             {
@@ -33,7 +33,7 @@
     <licenses>
         <license>
             <name>Apache 2.0</name>
-            <url>https://github.com/SheetJS/sheetjs/blob/master/LICENSE</url>
+            <url>https://git.sheetjs.com/sheetjs/sheetjs/src/branch/master/LICENSE</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
@@ -63,7 +63,7 @@
                                 <unzip src="${project.build.directory}/${project.artifactId}.zip" dest="${project.build.directory}/${upstream.version}" />
                                 <echo message="moving resources" />
                                 <move todir="${destDir}">
-                                    <fileset dir="${project.build.directory}/${upstream.version}/sheetjs-${upstream.version}/dist" />
+                                    <fileset dir="${project.build.directory}/${upstream.version}/sheetjs/dist" />
                                 </move>
                             </target>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>sheetjs</artifactId>
-    <version>0.18.7</version>
+    <version>0.18.7-SNAPSHOT</version>
     <name>sheetjs</name>
     <description>WebJar for sheetjs</description>
     <url>http://webjars.org</url>


### PR DESCRIPTION
About two years ago, sheetjs moved their source code from https://github.com/SheetJS/sheetjs to https://git.sheetjs.com/sheetjs/sheetjs. 

I've updated the recipe for building the webjar to reflect this change, updating links to the upstream repository in the `pom.xml` and `README.md` files. The structure of the distribution also changed slightly, so I updated the build to take this change into account. 

I'm not sure if this is the right place to bump the version number, but I've also updated the version number to `0.18.7`, since that is the version number of the stable release that I would be interested in.